### PR TITLE
Adding service for members forms data

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -46,12 +46,13 @@ member_service = MemberService()
 member_general_data_service = MembersGeneralDataService()
 member_reference_service = MembersReferenceService()
 member_dew_service = MembersDEWService()
+preaching_point_service = PreachingPointService()
 app.include_router(MemberRouter(member_service, member_general_data_service, member_reference_service,
-                                member_dew_service)
+                                member_dew_service, preaching_point_service)
                    .get_router())
 
 # Preaching points
-app.include_router(PreachingPointRouter(PreachingPointService()).get_router())
+app.include_router(PreachingPointRouter(preaching_point_service).get_router())
 
 # Enum types
 app.include_router(EnumTypeRouter().get_router())

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,10 +6,14 @@ from app.models.enum_type import (
     LeadershipType,
     LeavingReasonType,
     MaritalStatusType,
-    RoleType
+    RoleType,
+    KeyValueResponse
 )
 from app.models.health import HealthReponse
-from app.models.member import MemberListItemResponse, MemberPersonalInformationResponse, MemberBasicData
+from app.models.member import (MemberListItemResponse,
+                               MemberPersonalInformationResponse,
+                               MemberBasicData,
+                               MemberInitFormResponse)
 from app.models.member_dew import MembersDEWResponse
 from app.models.member_general_data import MemberGeneralDataResponse
 from app.models.member_references import MemberReferenceResponse, MembersReferenceElement

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,13 +7,13 @@ from app.models.enum_type import (
     LeavingReasonType,
     MaritalStatusType,
     RoleType,
-    KeyValueResponse
+    NameValueResponse
 )
 from app.models.health import HealthReponse
 from app.models.member import (MemberListItemResponse,
                                MemberPersonalInformationResponse,
                                MemberBasicData,
-                               MemberInitFormResponse)
+                               MemberFormValuesResponse)
 from app.models.member_dew import MembersDEWResponse
 from app.models.member_general_data import MemberGeneralDataResponse
 from app.models.member_references import MemberReferenceResponse, MembersReferenceElement

--- a/app/models/enum_type.py
+++ b/app/models/enum_type.py
@@ -66,6 +66,6 @@ class BloodType(str, enum.Enum):
     o_positive = "O+"
     o_negative = "O-"
 
-class KeyValueResponse(BaseModel):
+class NameValueResponse(BaseModel):
     name: str
     value: str

--- a/app/models/enum_type.py
+++ b/app/models/enum_type.py
@@ -1,5 +1,8 @@
 import enum
 
+from pydantic import BaseModel
+
+
 class MaritalStatusType(str, enum.Enum):
     soltero = "Soltero(a)"
     casado = "Casado(a)"
@@ -62,3 +65,7 @@ class BloodType(str, enum.Enum):
     ab_negative = "AB-"
     o_positive = "O+"
     o_negative = "O-"
+
+class KeyValueResponse(BaseModel):
+    name: str
+    value: str

--- a/app/models/member.py
+++ b/app/models/member.py
@@ -1,25 +1,26 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Dict, List
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator, field_serializer
 
 from app.models.enum_serializer import serialized_enum_by_name
-from app.models.enum_type import GenderType, RoleType, LeadershipType, CellLeadershipType, BloodType
+from app.models.enum_type import GenderType, RoleType, LeadershipType, CellLeadershipType, BloodType, KeyValueResponse
 from app.models.preaching_point import PreachingPointInformation
 
-"""
-This class makes it easier when loading zone pastor data as part of the member data.
-"""
+
 class MemberName(BaseModel):
+    """
+    This class makes it easier when loading zone pastor data as part of the member data.
+    """
     names: str
     surnames: str
 
     model_config = ConfigDict(from_attributes=True)
 
-"""
-This class makes it easier when loading zone pastor and the id data as part of the member data.
-"""
 class MemberBasicData(BaseModel):
+    """
+    This class makes it easier when loading zone pastor and the id data as part of the member data.
+    """
     id: int
     names: str
     surnames: str
@@ -101,3 +102,14 @@ class MemberPersonalInformationResponse(BaseModel):
         from_attributes=True,
         populate_by_name=True
     )
+
+class MemberInitFormResponse(BaseModel):
+    """
+        This class allows to return all the data needed to show/create/update the members
+    """
+    enums: Dict[str, List[KeyValueResponse]] = Field(description="Member init form enums")
+    zone_pastors: List[MemberBasicData] = Field(description="Member zone pastor list", alias="zonePastors")
+    preaching_points: List[PreachingPointInformation] = Field(description="Preaching point list", alias="preachingPoints")
+
+    class Config:
+        populate_by_name = True

--- a/app/models/member.py
+++ b/app/models/member.py
@@ -4,7 +4,7 @@ from typing import Optional, Dict, List
 from pydantic import BaseModel, ConfigDict, Field, model_validator, field_serializer
 
 from app.models.enum_serializer import serialized_enum_by_name
-from app.models.enum_type import GenderType, RoleType, LeadershipType, CellLeadershipType, BloodType, KeyValueResponse
+from app.models.enum_type import GenderType, RoleType, LeadershipType, CellLeadershipType, BloodType, NameValueResponse
 from app.models.preaching_point import PreachingPointInformation
 
 
@@ -103,11 +103,11 @@ class MemberPersonalInformationResponse(BaseModel):
         populate_by_name=True
     )
 
-class MemberInitFormResponse(BaseModel):
+class MemberFormValuesResponse(BaseModel):
     """
         This class allows to return all the data needed to show/create/update the members
     """
-    enums: Dict[str, List[KeyValueResponse]] = Field(description="Member init form enums")
+    enums: Dict[str, List[NameValueResponse]] = Field(description="Member init form enums")
     zone_pastors: List[MemberBasicData] = Field(description="Member zone pastor list", alias="zonePastors")
     preaching_points: List[PreachingPointInformation] = Field(description="Preaching point list", alias="preachingPoints")
 

--- a/app/models/member.py
+++ b/app/models/member.py
@@ -111,5 +111,6 @@ class MemberInitFormResponse(BaseModel):
     zone_pastors: List[MemberBasicData] = Field(description="Member zone pastor list", alias="zonePastors")
     preaching_points: List[PreachingPointInformation] = Field(description="Preaching point list", alias="preachingPoints")
 
-    class Config:
-        populate_by_name = True
+    model_config = ConfigDict(
+        populate_by_name=True
+    )

--- a/app/models/member_dew.py
+++ b/app/models/member_dew.py
@@ -11,8 +11,8 @@ class MembersDEWResponse(BaseModel):
     worker_1: Optional[str] = Field(description="Worker 1", alias="worker1")
     worker_2: Optional[str] = Field(description="Worker 2", alias="worker2")
     is_sharing_testimony: Optional[bool] = Field(description="Is sharing testimony", alias="isSharingTestimony")
-    is_publishing_testimony: Optional[bool] = Field(description="Is publishing testimony", alias="isPubilshingTestimony")
-    is_publishing_testimony_name: Optional[bool] = Field(description="Is publishing testimony name", alias="isPubilshingTestimonyName")
+    is_publishing_testimony: Optional[bool] = Field(description="Is publishing testimony", alias="isPublishingTestimony")
+    is_publishing_testimony_name: Optional[bool] = Field(description="Is publishing testimony name", alias="isPublishingTestimonyName")
     is_agreed_share_testimony: Optional[bool] = Field(description="Is agreed share", alias="isAgreedShareTestimony")
 
     model_config = ConfigDict(

--- a/app/routers/enum_type.py
+++ b/app/routers/enum_type.py
@@ -1,32 +1,9 @@
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from fastapi import Query
 
-from app.models import (
-    MaritalStatusType,
-    GenderType,
-    RoleType,
-    CellLeadershipType,
-    LeadershipType,
-    HousingType,
-    LeavingReasonType,
-    BloodType
-)
-from app.services import AuthService
-
-
-enum_map = {
-    "marital-status": MaritalStatusType,
-    "gender": GenderType,
-    "role": RoleType,
-    "cell-leadership": CellLeadershipType,
-    "leadership": LeadershipType,
-    "housing": HousingType,
-    "leaving-reason": LeavingReasonType,
-    "blood-type": BloodType,
-
-}
+from app.services import AuthService, get_enums_by_names
 
 class EnumTypeRouter:
     def __init__(self):
@@ -41,19 +18,4 @@ class EnumTypeRouter:
         @self.router.get("/")
         # dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
         def get_enums(names: Optional[list[str]] = Query(None, alias="names")):
-            response = {}
-            if not names:
-                selected_enum_map = enum_map
-            else:
-                selected_enum_map = {}
-                for name in names:
-                    enum_class = enum_map.get(name)
-                    if not enum_class:
-                        raise HTTPException(status_code=404, detail=f"Enum '{name}' not found")
-                    selected_enum_map[name] = enum_class
-
-            for name, enum_class in selected_enum_map.items():
-                response[name] = [{"name": e.name, "value": e.value} for e in enum_class]
-
-            return response
-
+            return get_enums_by_names(names)

--- a/app/routers/member.py
+++ b/app/routers/member.py
@@ -9,7 +9,7 @@ from app.models import (
     MemberGeneralDataResponse,
     MemberReferenceResponse,
     MembersDEWResponse, CellLeadershipType,
-    parse_enum_by_name, MemberBasicData, MemberInitFormResponse,
+    parse_enum_by_name, MemberBasicData, MemberFormValuesResponse,
 )
 from app.services import (
     AuthService,
@@ -49,7 +49,7 @@ class MemberRouter:
 
         @self.router.get(
             "/init-form",
-            response_model=MemberInitFormResponse,
+            response_model=MemberFormValuesResponse,
             # dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
         )
         def get_init_data(db: Session = Depends(get_db)):
@@ -60,7 +60,7 @@ class MemberRouter:
             zone_pastors = self.member_service.get_all_by_cell_leadership(CellLeadershipType.pastor_zona, db)
             preaching_points = self.preaching_point_service.get_all(db)
 
-            return MemberInitFormResponse(
+            return MemberFormValuesResponse(
                 enums=enums,
                 zone_pastors=zone_pastors,
                 preaching_points=preaching_points

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -3,7 +3,6 @@ from sqlalchemy.orm import Session
 
 from app.database.connection import get_db
 from app.models.user import UserResponse
-from app.services.user import UserService
 from app.services.auth import AuthService
 from app.services.user import UserService
 

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -6,3 +6,4 @@ from app.services.member_general_data import MembersGeneralDataService
 from app.services.member_references import MembersReferenceService
 from app.services.preaching_point import PreachingPointService
 from app.services.user import UserService
+from app.services.enum_type import get_enums_by_names

--- a/app/services/enum_type.py
+++ b/app/services/enum_type.py
@@ -6,7 +6,7 @@ from app.models import (
     MaritalStatusType, GenderType,
     RoleType, CellLeadershipType,
     LeadershipType, HousingType,
-    LeavingReasonType, BloodType, KeyValueResponse,
+    LeavingReasonType, BloodType, NameValueResponse,
 )
 
 enum_map = {
@@ -20,7 +20,7 @@ enum_map = {
     "blood-type": BloodType,
 }
 
-def get_enums_by_names(names: list[str]) -> Dict[str, List[KeyValueResponse]]:
+def get_enums_by_names(names: list[str]) -> Dict[str, List[NameValueResponse]]:
     """
     Returns all the enums by the given names.
     :param names: enums names
@@ -34,10 +34,10 @@ def get_enums_by_names(names: list[str]) -> Dict[str, List[KeyValueResponse]]:
         for name in names:
             enum_class = enum_map.get(name)
             if not enum_class:
-                raise HTTPException(status_code=404, detail=f"Enum '{name}' not found")
+                raise HTTPException(status_code=400, detail=f"Enum '{name}' not found")
             selected_enum_map[name] = enum_class
 
     for name, enum_class in selected_enum_map.items():
-        response[name] = [KeyValueResponse(name=e.name, value=e.value) for e in enum_class]
+        response[name] = [NameValueResponse(name=e.name, value=e.value) for e in enum_class]
 
     return response

--- a/app/services/enum_type.py
+++ b/app/services/enum_type.py
@@ -1,0 +1,43 @@
+from typing import Dict, List
+
+from fastapi import HTTPException
+
+from app.models import (
+    MaritalStatusType, GenderType,
+    RoleType, CellLeadershipType,
+    LeadershipType, HousingType,
+    LeavingReasonType, BloodType, KeyValueResponse,
+)
+
+enum_map = {
+    "marital-status": MaritalStatusType,
+    "gender": GenderType,
+    "role": RoleType,
+    "cell-leadership": CellLeadershipType,
+    "leadership": LeadershipType,
+    "housing": HousingType,
+    "leaving-reason": LeavingReasonType,
+    "blood-type": BloodType,
+}
+
+def get_enums_by_names(names: list[str]) -> Dict[str, List[KeyValueResponse]]:
+    """
+    Returns all the enums by the given names.
+    :param names: enums names
+    :return: dictionary of enums
+    """
+    response = {}
+    if not names:
+        selected_enum_map = enum_map    # Return all the enums
+    else:
+        selected_enum_map = {}
+        for name in names:
+            enum_class = enum_map.get(name)
+            if not enum_class:
+                raise HTTPException(status_code=404, detail=f"Enum '{name}' not found")
+            selected_enum_map[name] = enum_class
+
+    for name, enum_class in selected_enum_map.items():
+        response[name] = [KeyValueResponse(name=e.name, value=e.value) for e in enum_class]
+
+    return response

--- a/app/services/member.py
+++ b/app/services/member.py
@@ -20,8 +20,8 @@ class MemberService:
     def get_all_by_cell_leadership(self, cell_leadership, db: Session) -> list[MemberBasicData] | None:
         """
         Returns all the members with a specific cell leadership
-        :param cell_leadership:
-        :param db:
+        :param cell_leadership: Cell leadership from CellLeadershipType
+        :param db: Database connection
         :return:
         """
         members = (db.query(Member.id, Member.names, Member.surnames)

--- a/app/services/member.py
+++ b/app/services/member.py
@@ -25,7 +25,7 @@ class MemberService:
         :return:
         """
         members = (db.query(Member.id, Member.names, Member.surnames)
-                   .filter(Member.cell_leadership == cell_leadership, Member.status == 'A').all())
+                   .filter(Member.cell_leadership == cell_leadership).all())
         if not members:
             return None
         return [MemberBasicData.model_validate(member) for member in members]

--- a/postgres/db_scripts/998_MOCK_members.sql
+++ b/postgres/db_scripts/998_MOCK_members.sql
@@ -1,3 +1,175 @@
+-- Inserts de datos de prueba para tablas
+
+-- TODO este archivo debe borrarse posteriormente!!!
+
+-- usuario - pass: 12345
+insert into users(username, password, full_name, role_id)
+values ('user', '$2a$12$QRrPDX6ChrRfqVBlyN6D5.zLFAGVidR69/OV8iXMjf8eKvXUg2on2', 'El Usuario de la Verdad', 1);
+
+-- Pastores de zona
+INSERT INTO members (
+    id_number, surnames, names, birthdate, birth_country, residence_country,
+    address, phone_number, cellphone_number, email, military_service,
+    studies_completed, degree_obtained, other_studies, company, occupation,
+    eps, rh, gender, role, commitment_date, preaching_point_id,
+    cell_leadership, leadership, reasons_for_congregating
+) VALUES
+('100000001', 'Martínez López', 'Carlos Andrés', '1980-03-10', 'Colombia', 'Colombia',
+ 'Calle 10 #5-30', '2345678', '3001234567', 'carlos.martinez@iglesia.org', 'cumplido',
+ 'Universidad', 'Teología', 'Consejería Pastoral', 'Iglesia Betel', 'Pastor',
+ 'Sanitas', 'o_positive', 'masculino', 'miembro', '2010-05-15', 1,
+ 'pastor_zona', 'no_aplica', 'Deseo servir en comunidad'),
+
+('7008282', 'Rojas Pérez', 'María Fernanda', '1985-07-25', 'Colombia', 'Colombia',
+ 'Carrera 50 #20-60', '2456789', '3012345678', 'maria.rojas@iglesia.org', NULL,
+ 'Universidad', 'Teología', NULL, 'Templo Belén', 'Pastora',
+ 'Compensar', 'a_negative', 'femenino', 'miembro', '2012-09-10', 2,
+ 'pastor_zona', 'musico', null);
+
+-- Miembros asociados al pastor Carlos Andrés
+INSERT INTO members (
+    id_number, surnames, names, birthdate, birth_country, residence_country,
+    address, phone_number, cellphone_number, email, military_service,
+    studies_completed, degree_obtained, other_studies, company, occupation,
+    eps, rh, gender, role, commitment_date, preaching_point_id,
+    zone_pastor_id, cell_leadership, leadership, reasons_for_congregating
+) VALUES
+('8004455984', 'Gómez Ruiz', 'Andrés Felipe', '1995-01-12', 'Colombia', 'Colombia',
+ 'Calle 8 #3-20', NULL, '3101234567', 'andres.gomez@correo.com', NULL,
+ 'Bachillerato', NULL, NULL, 'SENA', 'Estudiante',
+ 'Sura', 'b_positive', 'masculino', 'miembro', '2021-03-22', 1,
+ (SELECT id from members WHERE id_number='100000001'),
+ 'nuevo_creyente', 'musico', 'Por invitación de un amigo'),
+
+('188293871', 'Salazar Meza', 'Laura Cristina', '1998-09-17', 'Colombia', 'Colombia',
+ 'Diagonal 30 #15-42', NULL, '3122345678', 'laura.salazar@correo.com', NULL,
+ 'Universidad', 'Psicología', NULL, NULL, 'Asistente',
+ 'Coomeva', null, 'femenino', 'miembro', '2022-06-11', 1,
+ (SELECT id from members WHERE id_number='100000001'), 'padre_espiritual', 'maestro_junior', 'Buscaba una iglesia activa'),
+
+('488282', 'Zapata Ocampo', 'Daniel Esteban', '2000-11-03', 'Colombia', 'Colombia',
+ 'Carrera 40 #11-11', NULL, '3133456789', 'daniel.zapata@correo.com', NULL,
+ 'Técnico', NULL, NULL, 'Taller Zapata', 'Técnico Automotriz',
+ 'Nueva EPS', 'ab_positive', 'masculino', 'miembro', '2020-08-05', 1,
+ (SELECT id from members WHERE id_number='100000001'), 'lider_asociado', 'no_aplica', 'Me sentí acogido');
+
+-- Miembros asociados a la pastora María Fernanda
+INSERT INTO members (
+    id_number, surnames, names, birthdate, birth_country, residence_country,
+    address, phone_number, cellphone_number, email, military_service,
+    studies_completed, degree_obtained, other_studies, company, occupation,
+    eps, rh, gender, role, commitment_date, preaching_point_id,
+    zone_pastor_id, cell_leadership, leadership, reasons_for_congregating
+) VALUES
+('1231423', 'Valencia Torres', 'Sandra Milena', '1992-05-14', 'Colombia', 'Colombia',
+ 'Calle 25 #16-90', NULL, '3144567890', 'sandra.valencia@correo.com', NULL,
+ 'Universidad', 'Administración', NULL, NULL, 'Administradora',
+ 'Famisanar', 'a_positive', 'femenino', 'miembro', '2019-04-20', 2,
+ (SELECT id from members WHERE id_number='7008282'), 'lider_celula', 'maestro_180', 'Vi transformación en mi familia'),
+
+('94585858', 'Castaño Restrepo', 'Jorge Iván', '1990-12-29', 'Colombia', 'Colombia',
+ 'Carrera 22 #33-44', NULL, '3155678901', 'jorge.castano@correo.com', 'exento',
+ 'Universidad', 'Ingeniería de Sistemas', NULL, 'TechSoft', 'Desarrollador',
+ 'Sura', 'o_negative', null, 'visitante', '2018-07-18', 2,
+ (SELECT id from members WHERE id_number='7008282'), 'obrero', 'maestro_universitario', 'Deseo servir a Dios con mis talentos');
+
+-- INSERTS PARA members_general_data
+INSERT INTO members_general_data (
+    member_id,
+    conversion_date,
+    conversion_place,
+    baptism_date,
+    baptism_place,
+    baptism_holy_spirit_date,
+    baptism_holy_spirit_place,
+    baptism_pastor_name,
+    baptism_denomination,
+    active_member_since,
+    leaving_reason,
+    leaving_reason_description,
+    leaving_date,
+    acceptance_comment
+) VALUES (
+    1,
+    '2010-05-15',
+    'Ciudad Esperanza',
+    '2011-06-20',
+    'Iglesia Central',
+    '2012-01-10',
+    'Campamento Juvenil',
+    'Pastor Juan Pérez',
+    'Evangelista Libre',
+    '2011-06-20',
+    'cambio_iglesia',
+    'Traslado a congregación local',
+    '2023-09-01',
+    'Miembro activo durante 12 años, participación destacada en actividades juveniles.'
+);
+
+INSERT INTO members_general_data (
+    member_id,
+    conversion_date,
+    conversion_place,
+    baptism_date,
+    baptism_place,
+    baptism_holy_spirit_date,
+    baptism_holy_spirit_place,
+    baptism_pastor_name,
+    baptism_denomination,
+    active_member_since,
+    leaving_reason,
+    leaving_reason_description,
+    leaving_date,
+    acceptance_comment
+) VALUES (
+    3,
+    '2015-03-22',
+    'Villa Paz',
+    '2016-04-10',
+    'Iglesia del Norte',
+    '2016-08-05',
+    'Retiro de Invierno',
+    'Pastora Elena Gómez',
+    'Comunidad Renovada',
+    '2016-04-10',
+    'muerte',
+    'Falleció por causas naturales',
+    '2022-11-15',
+    'Persona muy apreciada por la comunidad, dejó un legado espiritual fuerte.'
+);
+
+INSERT INTO members_general_data (
+    member_id,
+    conversion_date,
+    conversion_place,
+    baptism_date,
+    baptism_place,
+    baptism_holy_spirit_date,
+    baptism_holy_spirit_place,
+    baptism_pastor_name,
+    baptism_denomination,
+    active_member_since,
+    leaving_reason,
+    leaving_reason_description,
+    leaving_date,
+    acceptance_comment
+) VALUES (
+    2,
+    '2015-03-22',
+    'Villa Paz',
+    '2016-04-10',
+    'Iglesia del Norte',
+    '2016-08-05',
+    'Retiro de Invierno',
+    'Pastora Elena Gómez',
+    'Comunidad Renovada',
+    '2016-04-10',
+    null,
+    null,
+    null,
+    null
+);
+
 insert into members (id_number, surnames, names, birthdate, birth_country, residence_country, address, phone_number, cellphone_number, email, military_service, studies_completed, degree_obtained, other_studies, company, occupation, eps, rh, gender, role, commitment_date, preaching_point_id, zone_pastor_id, cell_leadership, leadership, reasons_for_congregating, status, created_by, updated_by) values ('343256429071511', 'Deem Deem', 'Ari Ari', '1973-01-17 11:44:41', 'Indonesia', 'China', '719 Thackeray Point', null, '(877) 5912707', 'adeemdeem0@google.ru', null, null, null, null, null, 'Human Resources Assistant III', 'nueva eps', 'o_positive', null, 'miembro', '2023-12-10 10:49:25', 11, 1, 'pastor_zona', 'maestro_universitario', null, 'A', 'developer', 'developer');
 insert into members (id_number, surnames, names, birthdate, birth_country, residence_country, address, phone_number, cellphone_number, email, military_service, studies_completed, degree_obtained, other_studies, company, occupation, eps, rh, gender, role, commitment_date, preaching_point_id, zone_pastor_id, cell_leadership, leadership, reasons_for_congregating, status, created_by, updated_by) values ('4041376352316', 'Vinden Vinden', 'Delly Delly', null, null, 'Mexico', '61854 Hansons Alley', null, '(900) 7314253', 'dvindenvinden1@vkontakte.ru', null, null, null, null, null, null, 'medimas', null, null, 'inactivo', '2024-02-09 22:06:31', 3, 1, 'lider_asociado', 'maestro_universitario', null, 'A', 'developer', 'SYS');
 insert into members (id_number, surnames, names, birthdate, birth_country, residence_country, address, phone_number, cellphone_number, email, military_service, studies_completed, degree_obtained, other_studies, company, occupation, eps, rh, gender, role, commitment_date, preaching_point_id, zone_pastor_id, cell_leadership, leadership, reasons_for_congregating, status, created_by, updated_by) values ('370733934158054', 'Gatesman Gatesman', 'Benny Benny', '2005-05-09 15:09:14', 'Nigeria', 'Indonesia', '3 Logan Plaza', null, '(999) 2685537', 'bgatesmangatesman2@smugmug.com', null, 'Politeknik Negeri Lhokseumawe', null, null, null, null, null, null, 'masculino', 'visitante', '2024-02-16 03:07:30', 17, 1, 'lider_celula', 'maestro_180', null, 'I', 'erika', 'erika');

--- a/postgres/db_scripts/999_tests_inserts.sql
+++ b/postgres/db_scripts/999_tests_inserts.sql
@@ -1,174 +1,4 @@
--- Inserts de datos de prueba para tablas
-
--- TODO este archivo debe borrarse posteriormente!!!
-
--- usuario - pass: 12345
-insert into users(username, password, full_name, role_id)
-values ('user', '$2a$12$QRrPDX6ChrRfqVBlyN6D5.zLFAGVidR69/OV8iXMjf8eKvXUg2on2', 'El Usuario de la Verdad', 1);
-
--- Pastores de zona
-INSERT INTO members (
-    id_number, surnames, names, birthdate, birth_country, residence_country,
-    address, phone_number, cellphone_number, email, military_service,
-    studies_completed, degree_obtained, other_studies, company, occupation,
-    eps, rh, gender, role, commitment_date, preaching_point_id,
-    cell_leadership, leadership, reasons_for_congregating
-) VALUES
-('100000001', 'Martínez López', 'Carlos Andrés', '1980-03-10', 'Colombia', 'Colombia',
- 'Calle 10 #5-30', '2345678', '3001234567', 'carlos.martinez@iglesia.org', 'cumplido',
- 'Universidad', 'Teología', 'Consejería Pastoral', 'Iglesia Betel', 'Pastor',
- 'Sanitas', 'o_positive', 'masculino', 'miembro', '2010-05-15', 1,
- 'pastor_zona', 'no_aplica', 'Deseo servir en comunidad'),
-
-('7008282', 'Rojas Pérez', 'María Fernanda', '1985-07-25', 'Colombia', 'Colombia',
- 'Carrera 50 #20-60', '2456789', '3012345678', 'maria.rojas@iglesia.org', NULL,
- 'Universidad', 'Teología', NULL, 'Templo Belén', 'Pastora',
- 'Compensar', 'a_negative', 'femenino', 'miembro', '2012-09-10', 2,
- 'pastor_zona', 'musico', null);
-
--- Miembros asociados al pastor Carlos Andrés
-INSERT INTO members (
-    id_number, surnames, names, birthdate, birth_country, residence_country,
-    address, phone_number, cellphone_number, email, military_service,
-    studies_completed, degree_obtained, other_studies, company, occupation,
-    eps, rh, gender, role, commitment_date, preaching_point_id,
-    zone_pastor_id, cell_leadership, leadership, reasons_for_congregating
-) VALUES
-('8004455984', 'Gómez Ruiz', 'Andrés Felipe', '1995-01-12', 'Colombia', 'Colombia',
- 'Calle 8 #3-20', NULL, '3101234567', 'andres.gomez@correo.com', NULL,
- 'Bachillerato', NULL, NULL, 'SENA', 'Estudiante',
- 'Sura', 'b_positive', 'masculino', 'miembro', '2021-03-22', 1,
- (SELECT id from members WHERE id_number='100000001'),
- 'nuevo_creyente', 'musico', 'Por invitación de un amigo'),
-
-('188293871', 'Salazar Meza', 'Laura Cristina', '1998-09-17', 'Colombia', 'Colombia',
- 'Diagonal 30 #15-42', NULL, '3122345678', 'laura.salazar@correo.com', NULL,
- 'Universidad', 'Psicología', NULL, NULL, 'Asistente',
- 'Coomeva', null, 'femenino', 'miembro', '2022-06-11', 1,
- (SELECT id from members WHERE id_number='100000001'), 'padre_espiritual', 'maestro_junior', 'Buscaba una iglesia activa'),
-
-('488282', 'Zapata Ocampo', 'Daniel Esteban', '2000-11-03', 'Colombia', 'Colombia',
- 'Carrera 40 #11-11', NULL, '3133456789', 'daniel.zapata@correo.com', NULL,
- 'Técnico', NULL, NULL, 'Taller Zapata', 'Técnico Automotriz',
- 'Nueva EPS', 'ab_positive', 'masculino', 'miembro', '2020-08-05', 1,
- (SELECT id from members WHERE id_number='100000001'), 'lider_asociado', 'no_aplica', 'Me sentí acogido');
-
--- Miembros asociados a la pastora María Fernanda
-INSERT INTO members (
-    id_number, surnames, names, birthdate, birth_country, residence_country,
-    address, phone_number, cellphone_number, email, military_service,
-    studies_completed, degree_obtained, other_studies, company, occupation,
-    eps, rh, gender, role, commitment_date, preaching_point_id,
-    zone_pastor_id, cell_leadership, leadership, reasons_for_congregating
-) VALUES
-('1231423', 'Valencia Torres', 'Sandra Milena', '1992-05-14', 'Colombia', 'Colombia',
- 'Calle 25 #16-90', NULL, '3144567890', 'sandra.valencia@correo.com', NULL,
- 'Universidad', 'Administración', NULL, NULL, 'Administradora',
- 'Famisanar', 'a_positive', 'femenino', 'miembro', '2019-04-20', 2,
- (SELECT id from members WHERE id_number='7008282'), 'lider_celula', 'maestro_180', 'Vi transformación en mi familia'),
-
-('94585858', 'Castaño Restrepo', 'Jorge Iván', '1990-12-29', 'Colombia', 'Colombia',
- 'Carrera 22 #33-44', NULL, '3155678901', 'jorge.castano@correo.com', 'exento',
- 'Universidad', 'Ingeniería de Sistemas', NULL, 'TechSoft', 'Desarrollador',
- 'Sura', 'o_negative', null, 'visitante', '2018-07-18', 2,
- (SELECT id from members WHERE id_number='7008282'), 'obrero', 'maestro_universitario', 'Deseo servir a Dios con mis talentos');
-
--- INSERTS PARA members_general_data
-INSERT INTO members_general_data (
-    member_id,
-    conversion_date,
-    conversion_place,
-    baptism_date,
-    baptism_place,
-    baptism_holy_spirit_date,
-    baptism_holy_spirit_place,
-    baptism_pastor_name,
-    baptism_denomination,
-    active_member_since,
-    leaving_reason,
-    leaving_reason_description,
-    leaving_date,
-    acceptance_comment
-) VALUES (
-    1,
-    '2010-05-15',
-    'Ciudad Esperanza',
-    '2011-06-20',
-    'Iglesia Central',
-    '2012-01-10',
-    'Campamento Juvenil',
-    'Pastor Juan Pérez',
-    'Evangelista Libre',
-    '2011-06-20',
-    'cambio_iglesia',
-    'Traslado a congregación local',
-    '2023-09-01',
-    'Miembro activo durante 12 años, participación destacada en actividades juveniles.'
-);
-
-INSERT INTO members_general_data (
-    member_id,
-    conversion_date,
-    conversion_place,
-    baptism_date,
-    baptism_place,
-    baptism_holy_spirit_date,
-    baptism_holy_spirit_place,
-    baptism_pastor_name,
-    baptism_denomination,
-    active_member_since,
-    leaving_reason,
-    leaving_reason_description,
-    leaving_date,
-    acceptance_comment
-) VALUES (
-    3,
-    '2015-03-22',
-    'Villa Paz',
-    '2016-04-10',
-    'Iglesia del Norte',
-    '2016-08-05',
-    'Retiro de Invierno',
-    'Pastora Elena Gómez',
-    'Comunidad Renovada',
-    '2016-04-10',
-    'muerte',
-    'Falleció por causas naturales',
-    '2022-11-15',
-    'Persona muy apreciada por la comunidad, dejó un legado espiritual fuerte.'
-);
-
-INSERT INTO members_general_data (
-    member_id,
-    conversion_date,
-    conversion_place,
-    baptism_date,
-    baptism_place,
-    baptism_holy_spirit_date,
-    baptism_holy_spirit_place,
-    baptism_pastor_name,
-    baptism_denomination,
-    active_member_since,
-    leaving_reason,
-    leaving_reason_description,
-    leaving_date,
-    acceptance_comment
-) VALUES (
-    2,
-    '2015-03-22',
-    'Villa Paz',
-    '2016-04-10',
-    'Iglesia del Norte',
-    '2016-08-05',
-    'Retiro de Invierno',
-    'Pastora Elena Gómez',
-    'Comunidad Renovada',
-    '2016-04-10',
-    null,
-    null,
-    null,
-    null
-);
+-- TODO script que posteriormente debe eliminarse
 
 -- INSERTS para references
 
@@ -198,7 +28,6 @@ INSERT INTO members_references (
 
 insert into
     members_dew (
-        id,
         member_id,
         ministration_date,
         worker_1,
@@ -210,7 +39,6 @@ insert into
     )
 values
     (
-        1,
         1,
         '2024-12-14',
         'Antonie Klainman',
@@ -223,7 +51,6 @@ values
 
 insert into
     members_dew (
-        id,
         member_id,
         ministration_date,
         worker_1,
@@ -235,7 +62,6 @@ insert into
     )
 values
     (
-        2,
         2,
         '2024-12-30',
         'Elnore Klaffs',
@@ -248,7 +74,6 @@ values
 
 insert into
     members_dew (
-        id,
         member_id,
         ministration_date,
         worker_1,
@@ -260,7 +85,6 @@ insert into
     )
 values
     (
-        3,
         3,
         '2025-03-25',
         'Willette Yitzovitz',
@@ -273,7 +97,6 @@ values
 
 insert into
     members_dew (
-        id,
         member_id,
         ministration_date,
         worker_1,
@@ -285,7 +108,6 @@ insert into
     )
 values
     (
-        4,
         4,
         '2024-06-25',
         'Ruy Meneer',
@@ -298,7 +120,6 @@ values
 
 insert into
     members_dew (
-        id,
         member_id,
         ministration_date,
         worker_1,
@@ -310,7 +131,6 @@ insert into
     )
 values
     (
-        5,
         5,
         '2025-01-02',
         'Wally Flamank',
@@ -323,7 +143,6 @@ values
 
 insert into
     members_dew (
-        id,
         member_id,
         ministration_date,
         worker_1,
@@ -336,19 +155,17 @@ insert into
 values
     (
         6,
-        6,
         '2025-04-13',
         'Gabe Clare',
         'Donia de Merida',
-        false,
-        false,
-        false,
+        true,
+        true,
+        true,
         true
     );
 
 insert into
     members_dew (
-        id,
         member_id,
         ministration_date,
         worker_1,
@@ -360,7 +177,6 @@ insert into
     )
 values
     (
-        7,
         7,
         '2024-08-09',
         'Cindra Woolcocks',
@@ -373,7 +189,6 @@ values
 
 insert into
     members_dew (
-        id,
         member_id,
         ministration_date,
         worker_1,
@@ -385,7 +200,6 @@ insert into
     )
 values
     (
-        8,
         8,
         '2024-12-10',
         'Kasey Bonwell',
@@ -398,7 +212,6 @@ values
 
 insert into
     members_dew (
-        id,
         member_id,
         ministration_date,
         worker_1,
@@ -410,7 +223,6 @@ insert into
     )
 values
     (
-        9,
         9,
         '2025-02-09',
         'Erda Weadick',
@@ -423,7 +235,6 @@ values
 
 insert into
     members_dew (
-        id,
         member_id,
         ministration_date,
         worker_1,
@@ -435,7 +246,6 @@ insert into
     )
 values
     (
-        10,
         10,
         '2025-01-02',
         'Devina Chezelle',


### PR DESCRIPTION
**Servicio:** 

`GET members/init-form`

- Este servicio retorna todos los datos para los combobox relacionados a miembros
- Adicionalmente se dejan disponibles los servicios: `/enums/?names=enum-name...` y `/members/by-cell-leadership?value=role-name...` para futuros desarrollos

**Ejemplo de respuesta:**
[init-form.json](https://github.com/user-attachments/files/20398075/init-form.json)

**TODO:**

Procederé con los cambios en el front para llenar las listas con estos datos, ya que se había hecho con el servicio de /enums
