### PR TITLE
Table and models for ADN tab

### DIFF
--- a/app/database/member_adn.py
+++ b/app/database/member_adn.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, ForeignKey, String
+
+from app.database.connection import Base
+
+
+class MemberADN(Base):
+    __tablename__ = "members_adn"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    passion = Column(String(300))
+    mission = Column(String(300))
+    personal_prophecies = Column(String(300))
+    personal_values = Column(String(300))
+    one_year_plans = Column(String(300))
+    two_year_plans = Column(String(300))
+    five_year_plans = Column(String(300))
+    strengths = Column(String(300))
+    weaknesses = Column(String(300))
+    improvement_areas = Column(String(300))
+    mentor = Column(String(250))
+    mentor_frequency = Column(String(50))
+    mentee = Column(String(250))
+    mentee_frequency = Column(String(50))
+
+    member_id = Column(Integer, ForeignKey('members.id'), unique=True, nullable=False)

--- a/app/database/member_gift_ability.py
+++ b/app/database/member_gift_ability.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Integer, Column, ForeignKey, String, Enum
+
+from app.database.connection import Base
+from app.models.enum_type import GiftAbilityType
+
+
+class MemberGiftAbility(Base):
+    __tablename__ = 'members_gift_ability'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(150), nullable=False)
+    type = Column(Enum(GiftAbilityType, name="gift_ability_type", native_enum=False), nullable=False)
+
+    member_id = Column(Integer, ForeignKey('members.id'), unique=False, nullable=False)

--- a/app/models/enum_type.py
+++ b/app/models/enum_type.py
@@ -66,6 +66,12 @@ class BloodType(str, enum.Enum):
     o_positive = "O+"
     o_negative = "O-"
 
+class GiftAbilityType(str, enum.Enum):
+    main_gift = 'main_gift'
+    secondary_gift = 'secondary_gift'
+    acquired_skill = 'acquired_skill'
+    natural_ability = 'natural_ability'
+
 class NameValueResponse(BaseModel):
     name: str
     value: str

--- a/app/models/member_adn.py
+++ b/app/models/member_adn.py
@@ -1,0 +1,53 @@
+from typing import Optional, List
+
+from pydantic import BaseModel, Field, ConfigDict
+
+from app.models.enum_serializer import serialized_enum_by_name
+from app.models.enum_type import GiftAbilityType
+
+
+class MemberADNData(BaseModel):
+    member_id: int = Field(description="Member ID", alias="memberId")
+
+    passion: Optional[str] = Field(description="What you passionately desire to do for God", alias="passion")
+    mission: Optional[str] = Field(description="Mission statement", alias="mission")
+    personal_prophecies: Optional[str] = Field(description="Personal prophecies and impressions", alias="personalProphecies")
+    personal_values: Optional[str] = Field(description="Personal values", alias="personalValues")
+    one_year_plans: Optional[str] = Field(description="One-year plans", alias="oneYearPlans")
+    two_year_plans: Optional[str] = Field(description="Two-year plans", alias="twoYearPlans")
+    five_year_plans: Optional[str] = Field(description="Five-year plans", alias="fiveYearPlans")
+    strengths: Optional[str] = Field(description="Personal strengths", alias="strengths")
+    weaknesses: Optional[str] = Field(description="Personal weaknesses", alias="weaknesses")
+    improvement_areas: Optional[str] = Field(description="Areas you need to improve", alias="improvementAreas")
+    mentor: Optional[str] = Field(description="Mentor's name", alias="mentor")
+    mentor_frequency: Optional[str] = Field(description="Frequency of meeting with your mentors", alias="mentorFrequency")
+    mentee: Optional[str] = Field(description="People you mentor", alias="mentee")
+    mentee_frequency: Optional[str] = Field(description="Frequency with which you mentor", alias="menteeFrequency")
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True
+    )
+
+class MemberGiftAbilityData(BaseModel):
+    id: int = Field(description="Member gift ability ID", alias="id")
+    member_id: int = Field(description="Member ID", alias="memberId")
+
+    name: str = Field(description="Gift or ability name", alias="name")
+    type: serialized_enum_by_name(GiftAbilityType) = Field(description="Gift or ability type", alias="type")
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True
+    )
+
+class MemberADNResponse(BaseModel):
+    adn: MemberADNData = Field(description="Member ADN data", alias="adn")
+    main_gift_list: List[MemberGiftAbilityData] | [] = Field(description="List of main gifts", alias="mainGiftList")
+    secondary_gift_list: List[MemberGiftAbilityData] | [] = Field(description="List of secondary gifts", alias="secondaryGiftList")
+    acquired_skill_list: List[MemberGiftAbilityData] | [] = Field(description="List of acquired skills", alias="acquiredSkillList")
+    natural_ability: List[MemberGiftAbilityData] | [] = Field(description="List of natural abilities", alias="naturalAbilityList")
+
+    model_config = ConfigDict(
+        populate_by_name=True
+    )

--- a/postgres/db_scripts/009_members_adn.sql
+++ b/postgres/db_scripts/009_members_adn.sql
@@ -1,0 +1,48 @@
+-- Tables for ADN 1 and 2
+
+-- Questions from tabs adn1 and adn2
+
+CREATE TABLE members_adn
+(
+    id                  SERIAL PRIMARY KEY,
+
+    member_id           integer NOT NULL UNIQUE,
+    passion             VARCHAR(300),
+    mission             VARCHAR(300),
+    personal_prophecies VARCHAR(300),
+    personal_values     VARCHAR(300),
+    one_year_plans      VARCHAR(300),
+    two_year_plans      VARCHAR(300),
+    five_year_plans     VARCHAR(300),
+    strengths           VARCHAR(300),
+    weaknesses          VARCHAR(300),
+    improvement_areas   VARCHAR(300),
+    mentor              VARCHAR(250),
+    mentor_frequency    VARCHAR(50),
+    mentee              VARCHAR(250),
+    mentee_frequency    VARCHAR(50)
+
+);
+
+-- Table for: Dones espirituales (principales / secundarios) + Habilidades naturales + Habilidades adquiridas
+
+CREATE TYPE gift_ability_type AS ENUM ('main_gift', 'secondary_gift', 'acquired_skill', 'natural_ability');
+
+CREATE TABLE members_gift_ability
+(
+    id        SERIAL PRIMARY KEY,
+
+    member_id integer NOT NULL,
+    name      VARCHAR(150) NOT NULL,
+    type      gift_ability_type NOT NULL
+
+);
+
+-- Relations with members
+ALTER TABLE members_adn
+    ADD CONSTRAINT FK_members_members_adn FOREIGN KEY (member_id)
+        REFERENCES members (id);
+
+ALTER TABLE members_gift_ability
+    ADD CONSTRAINT FK_members_members_gift_ability FOREIGN KEY (member_id)
+        REFERENCES members (id);

--- a/postgres/db_scripts/999_tests_inserts.sql
+++ b/postgres/db_scripts/999_tests_inserts.sql
@@ -255,3 +255,48 @@ values
         false,
         false
     );
+
+
+-- Inserts para ADN
+
+INSERT INTO members_adn (member_id, passion, mission, personal_prophecies, personal_values, one_year_plans, two_year_plans, five_year_plans, strengths, weaknesses, improvement_areas, mentor, mentor_frequency, mentee, mentee_frequency) VALUES
+(1, 'Ayudar a los demás', 'Impactar positivamente', 'Tendrás gran influencia', 'Empatía, justicia', 'Desarrollar habilidades sociales', 'Iniciar un proyecto personal', 'Fundar una ONG', 'Comunicación, liderazgo', 'Impaciencia', 'Manejo del estrés', 'Juan Pérez', 'Mensual', 'Laura Gómez', 'Semanal'),
+(2, 'Crear arte', 'Inspirar a otros', 'Tu arte tocará vidas', 'Creatividad, sensibilidad', 'Mejorar técnica de dibujo', 'Exponer en una galería', 'Vivir del arte', 'Imaginación, detalle', 'Indecisión', 'Autodisciplina', 'Ana Torres', 'Quincenal', 'Mario Ruiz', 'Mensual'),
+(3, 'Explorar el mundo', 'Conectar culturas', 'Verás lugares lejanos', 'Curiosidad, respeto', 'Viajar por el país', 'Aprender nuevos idiomas', 'Escribir un libro de viajes', 'Adaptabilidad, comunicación', 'Desorganización', 'Planificación', 'Luis Ríos', 'Mensual', 'Carmen Silva', 'Mensual'),
+(4, 'Investigar', 'Resolver problemas complejos', 'Descubrirás algo importante', 'Lógica, dedicación', 'Iniciar tesis', 'Publicar artículo', 'Trabajar en investigación', 'Pensamiento crítico', 'Perfeccionismo', 'Gestión de tiempo', null, null, 'Pedro Díaz', 'Semanal'),
+(5, 'Emprender', 'Crear soluciones útiles', 'Liderarás una empresa', 'Innovación, valentía', 'Identificar necesidades del mercado', 'Lanzar prototipo', 'Escalar startup', 'Creatividad, resiliencia', 'Ansiedad', 'Delegar', 'Sofía Jiménez', 'Quincenal', 'Andrés León', 'Quincenal'),
+(6, 'Sanar', 'Mejorar la salud de otros', 'Tendrás manos curativas', 'Compasión, responsabilidad', 'Estudiar medicina alternativa', 'Practicar con pacientes', 'Abrir clínica', 'Empatía, conocimientos médicos', 'Autoexigencia', 'Trabajo en equipo', 'Fernando Peña', 'Mensual', 'Natalia Mora', 'Mensual'),
+(7, 'Enseñar', 'Transformar vidas con educación', 'Serás luz en caminos oscuros', 'Paciencia, vocación', 'Diseñar un curso', 'Capacitarme en nuevas metodologías', 'Fundar una escuela', 'Claridad, carisma', 'Falta de confianza', 'Autoafirmación', 'Marcela Vargas', 'Semanal', 'Julián Soto', 'Semanal'),
+(8, 'Escribir', 'Transmitir ideas poderosas', 'Tus palabras cambiarán mentes', 'Veracidad, pasión', 'Publicar un blog', 'Participar en concursos', 'Escribir una novela', 'Expresión escrita, observación', 'Procrastinación', 'Organización', 'Renato Cuevas', 'Mensual', 'Daniela Torres', 'Quincenal'),
+(9, 'Servir', 'Apoyar a comunidades vulnerables', 'Serás puente de esperanza', 'Solidaridad, acción', 'Voluntariado regular', 'Organizar colectas', 'Dirigir una fundación', 'Escucha, gestión', 'Inseguridad', 'Autoconfianza', 'Adriana Ruiz', 'Mensual', 'Carlos Peña', 'Mensual'),
+(10, 'Innovar en tecnología', 'Resolver desafíos globales', 'Crearás algo revolucionario', 'Precisión, lógica', 'Desarrollar app de impacto social', 'Conseguir socios estratégicos', 'Fundar una tech for good', 'Resolución de problemas', 'Impaciencia', 'Escucha activa', 'Iván Torres', 'Quincenal', null, null);
+
+INSERT INTO members_gift_ability (member_id, name, type) VALUES
+(1, 'Discernimiento espiritual', 'main_gift'),
+(1, 'Liderazgo', 'natural_ability'),
+(1, 'Paciencia', 'natural_ability'),
+(1, 'Resolución de conflictos', 'acquired_skill'),
+(1, 'Estoicidad', 'acquired_skill');
+
+-- member_id: 2
+INSERT INTO members_gift_ability (member_id, name, type) VALUES
+(2, 'Enseñanza', 'main_gift'),
+(2, 'Empatía', 'secondary_gift'),
+(2, 'Manejo de herramientas digitales', 'acquired_skill');
+
+-- member_id: 3
+INSERT INTO members_gift_ability (member_id, name, type) VALUES
+(3, 'Servicio', 'main_gift'),
+(3, 'Organización', 'natural_ability');
+
+-- member_id: 4
+INSERT INTO members_gift_ability (member_id, name, type) VALUES
+(4, 'Palabra de conocimiento', 'main_gift'),
+(4, 'Comunicación efectiva', 'acquired_skill'),
+(4, 'Intuición', 'natural_ability');
+
+-- member_id: 5
+INSERT INTO members_gift_ability (member_id, name, type) VALUES
+(5, 'Fe', 'secondary_gift'),
+(5, 'Diseño gráfico', 'acquired_skill'),
+(5, 'Pensamiento analítico', 'natural_ability');


### PR DESCRIPTION
Closes #55 

He organizado los textarea de los dos tabs (ADN 1 y 2) en una tabla: members_adn.

Las cosas que son listas de estos tabs (dones espirituales, habilidades naturales y habilidades adquiridas) las he organizado en la tabla: members_gift_ability, clasificándolos en distintos tipos (por el campo type).

![image](https://github.com/user-attachments/assets/f4cd42be-870c-4e75-9b1f-beb0305207ab)

Se incluye el modelo de respuesta que devolverá las habilidades clasificadas en distintas listas, además de los campos de textarea de los tabs de ADN:

```
class MemberADNResponse(BaseModel):
    adn: MemberADNData = Field(description="Member ADN data", alias="adn")
    main_gift_list: List[MemberGiftAbilityData] | [] = Field(description="List of main gifts", alias="mainGiftList")
    secondary_gift_list: List[MemberGiftAbilityData] | [] = Field(description="List of secondary gifts", alias="secondaryGiftList")
    acquired_skill_list: List[MemberGiftAbilityData] | [] = Field(description="List of acquired skills", alias="acquiredSkillList")
    natural_ability: List[MemberGiftAbilityData] | [] = Field(description="List of natural abilities", alias="naturalAbilityList")
    model_config = ConfigDict(
        populate_by_name=True
    )
```
