### PR TITLE
Post service for saving the general data. Reorganizing routers

### DIFF
--- a/app/exception_handler.py
+++ b/app/exception_handler.py
@@ -1,9 +1,7 @@
 from fastapi import FastAPI, Request, HTTPException, status
 from sqlalchemy.exc import IntegrityError
 
-from app.services import LogicConstraintViolationException
-from app.services.exception import NotFoundException
-
+from app.services import LogicConstraintViolationException, NotFoundException, ConflictException
 
 def setup_exception_handles(app: FastAPI) -> FastAPI:
     @app.exception_handler(IntegrityError)
@@ -17,5 +15,9 @@ def setup_exception_handles(app: FastAPI) -> FastAPI:
     @app.exception_handler(NotFoundException)
     async def not_found_exception(request: Request, exc: NotFoundException):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message)
+
+    @app.exception_handler(ConflictException)
+    async def conflict_exception(request: Request, exc: ConflictException):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.message)
 
     return app

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.exception_handler import setup_exception_handles
+from app.middlewares import UserAwareMiddleware
 from app.routers import (
     EnumTypeRouter,
     HealthRouter,
@@ -9,6 +10,8 @@ from app.routers import (
     MemberRouter,
     PreachingPointRouter,
     UserRouter,
+    MemberGeneralDataRouter,
+    MemberReferenceRouter, MemberDEWRouter, MemberFamilyDataRouter,
 )
 from app.services import (
     AuthService,
@@ -21,8 +24,6 @@ from app.services import (
     UserService,
     MembersFamilyDataService,
 )
-from app.middlewares import UserAwareMiddleware
-
 
 app = FastAPI()
 app.add_middleware(
@@ -53,19 +54,16 @@ app.include_router(UserRouter(user_service, auth_service).get_router())
 
 # Members
 member_service = MemberService()
-member_general_data_service = MembersGeneralDataService()
-member_reference_service = MembersReferenceService()
-member_dew_service = MembersDEWService()
 preaching_point_service = PreachingPointService()
-member_family_data_service = MembersFamilyDataService()
 app.include_router(MemberRouter(member_service,
-                                member_general_data_service,
-                                member_reference_service,
-                                member_dew_service,
                                 preaching_point_service,
-                                member_family_data_service,
                                 auth_service)
                    .get_router())
+
+app.include_router(MemberGeneralDataRouter(MembersGeneralDataService(), auth_service).get_router())
+app.include_router(MemberReferenceRouter(MembersReferenceService(), auth_service).get_router())
+app.include_router(MemberDEWRouter(MembersDEWService(), auth_service).get_router())
+app.include_router(MemberFamilyDataRouter(MembersFamilyDataService(), auth_service).get_router())
 
 # Preaching points
 app.include_router(PreachingPointRouter(preaching_point_service, auth_service).get_router())

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -19,7 +19,7 @@ from app.models.member import (MemberListItemResponse,
                                UpdateMemberRequest,
                                )
 from app.models.member_dew import MembersDEWResponse
-from app.models.member_general_data import MemberGeneralDataResponse
+from app.models.member_general_data import MemberGeneralDataResponse, CreateMemberGeneralDataRequest
 from app.models.member_references import MemberReferenceResponse, MembersReferenceElement
 from app.models.preaching_point import PreachingPointInformation
 from app.models.role import RoleInformation

--- a/app/models/member_general_data.py
+++ b/app/models/member_general_data.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 from typing import Optional
 
 from pydantic import BaseModel, Field, ConfigDict
@@ -10,18 +10,39 @@ from app.models.enum_type import LeavingReasonType
 class MemberGeneralDataResponse(BaseModel):
     id: int = Field(description="Member general data information DB id")
     member_id: int = Field(description="Member ID", alias="memberId")
-    conversion_date: Optional[datetime] = Field(description="Conversion date", alias="conversionDate")
+    conversion_date: Optional[date] = Field(description="Conversion date", alias="conversionDate")
     conversion_place: Optional[str] = Field(description="Convertion place", alias="conversionPlace")
-    baptism_date: Optional[datetime] = Field(description="Baptism date", alias="baptismDate")
+    baptism_date: Optional[date] = Field(description="Baptism date", alias="baptismDate")
     baptism_place: Optional[str] = Field(description="Baptism place", alias="baptismPlace")
-    baptism_holy_spirit_date: Optional[datetime] = Field(description="Baptism holy spirit date", alias="baptismHolySpiritDate")
+    baptism_holy_spirit_date: Optional[date] = Field(description="Baptism holy spirit date", alias="baptismHolySpiritDate")
     baptism_holy_spirit_place: Optional[str] = Field(description="Baptism holy spirit place", alias="baptismHolySpiritPlace")
     baptism_pastor_name: Optional[str] = Field(description="Baptism pastor name", alias="baptismPastorName")
     baptism_denomination: Optional[str] = Field(description="Baptism denomination", alias="baptismDenomination")
-    active_member_since: Optional[datetime] = Field(description="Active member since", alias="activeMemberSince")
+    active_member_since: Optional[date] = Field(description="Active member since", alias="activeMemberSince")
     leaving_reason: Optional[serialized_enum_by_name(LeavingReasonType)] = Field(description="Leaving reason", alias="leavingReason")
     leaving_reason_description: Optional[str] = Field(description="Leaving reason", alias="leavingReasonDescription")
-    leaving_date: Optional[datetime] = Field(description="Leaving date", alias="leavingDate")
+    leaving_date: Optional[date] = Field(description="Leaving date", alias="leavingDate")
+    acceptance_comment: Optional[str] = Field(description="Acceptance comment", alias="acceptanceComment")
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True
+    )
+
+class CreateMemberGeneralDataRequest(BaseModel):
+    member_id: int = Field(description="Member ID", alias="memberId", gt=0)
+    conversion_date: Optional[date] = Field(description="Conversion date", alias="conversionDate")
+    conversion_place: Optional[str] = Field(description="Convertion place", alias="conversionPlace")
+    baptism_date: Optional[date] = Field(description="Baptism date", alias="baptismDate")
+    baptism_place: Optional[str] = Field(description="Baptism place", alias="baptismPlace")
+    baptism_holy_spirit_date: Optional[date] = Field(description="Baptism holy spirit date", alias="baptismHolySpiritDate")
+    baptism_holy_spirit_place: Optional[str] = Field(description="Baptism holy spirit place", alias="baptismHolySpiritPlace")
+    baptism_pastor_name: Optional[str] = Field(description="Baptism pastor name", alias="baptismPastorName")
+    baptism_denomination: Optional[str] = Field(description="Baptism denomination", alias="baptismDenomination")
+    active_member_since: Optional[date] = Field(description="Active member since", alias="activeMemberSince")
+    leaving_reason: Optional[serialized_enum_by_name(LeavingReasonType)] = Field(description="Leaving reason", alias="leavingReason")
+    leaving_reason_description: Optional[str] = Field(description="Leaving reason", alias="leavingReasonDescription")
+    leaving_date: Optional[date] = Field(description="Leaving date", alias="leavingDate")
     acceptance_comment: Optional[str] = Field(description="Acceptance comment", alias="acceptanceComment")
 
     model_config = ConfigDict(

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -4,3 +4,7 @@ from app.routers.login import LoginRouter
 from app.routers.member import MemberRouter
 from app.routers.preaching_point import PreachingPointRouter
 from app.routers.user import UserRouter
+from app.routers.member_general_data import MemberGeneralDataRouter
+from app.routers.member_reference import MemberReferenceRouter
+from app.routers.member_dew import MemberDEWRouter
+from app.routers.member_family_data import MemberFamilyDataRouter

--- a/app/routers/member.py
+++ b/app/routers/member.py
@@ -13,38 +13,26 @@ from app.models import (
     CreateMemberRequest,
     MemberListItemResponse,
     MemberPersonalInformationResponse,
-    MemberGeneralDataResponse,
-    MemberReferenceResponse,
-    MembersDEWResponse, CellLeadershipType,
+    CellLeadershipType,
     parse_enum_by_name,
     MemberBasicData,
     MemberFormValuesResponse,
-    MemberFamilyDataResponse, UpdateMemberRequest,
+    UpdateMemberRequest,
 )
 from app.services import (
     AuthService,
     MemberService,
-    MembersDEWService,
-    MembersGeneralDataService,
-    MembersReferenceService, get_enums_by_names,
-    PreachingPointService, MembersFamilyDataService,
-)
+    get_enums_by_names,
+    PreachingPointService, )
 
 
 class MemberRouter:
-    def __init__(self, member_service: MemberService,
-                 member_general_data_service: MembersGeneralDataService,
-                 member_reference_service: MembersReferenceService,
-                 member_dew_service: MembersDEWService,
+    def __init__(self,
+                 member_service: MemberService,
                  preaching_point_service: PreachingPointService,
-                 member_family_data_service: MembersFamilyDataService,
                  auth_service: AuthService):
         self.member_service = member_service
-        self.member_general_data_service = member_general_data_service
-        self.member_reference_service = member_reference_service
-        self.member_dew_service = member_dew_service
         self.preaching_point_service = preaching_point_service
-        self.member_family_data_service = member_family_data_service
         self.auth_service = auth_service
 
         self.router = APIRouter(prefix="/members", tags=["members"])
@@ -120,48 +108,3 @@ class MemberRouter:
             if not member:
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
             return member
-
-        @self.router.get(
-            "/{member_id}/general-data",
-            description="Get 'Member General Data' given the member ID",
-            response_model=MemberGeneralDataResponse,
-            # dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
-        )
-        def find_general_data_by_member_id(member_id : int, db: Session = Depends(get_db)):
-            member_general_data = self.member_general_data_service.find_by_id(member_id, db)
-            if not member_general_data:
-                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-            return member_general_data
-
-        @self.router.get(
-            "/{member_id}/references",
-            response_model=Optional[MemberReferenceResponse],
-            # dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
-        )
-        def find_references_by_id(member_id : int, db: Session = Depends(get_db)):
-            member_references = self.member_reference_service.find_by_id(member_id, db)
-            if not member_references:
-                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-            return member_references
-
-        @self.router.get(
-            "/{member_id}/dew",
-            response_model=Optional[MembersDEWResponse],
-            # dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
-        )
-        def find_dew_by_id(member_id : int, db: Session = Depends(get_db)):
-            member_dew = self.member_dew_service.find_by_id(member_id, db)
-            if not member_dew:
-                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-            return member_dew
-
-        @self.router.get(
-            "/{member_id}/family-data",
-            response_model=Optional[MemberFamilyDataResponse],
-            # dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
-        )
-        def find_family_data_by_id(member_id : int, db: Session = Depends(get_db)):
-            member_family_data = self.member_family_data_service.find_by_member_id(member_id, db)
-            if not member_family_data:
-                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-            return member_family_data

--- a/app/routers/member_dew.py
+++ b/app/routers/member_dew.py
@@ -1,0 +1,44 @@
+from typing import Optional
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    status,
+)
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import (
+    MembersDEWResponse, )
+from app.services import (
+    AuthService,
+    MembersDEWService,
+)
+
+
+class MemberDEWRouter:
+    def __init__(self,
+                 member_dew_service: MembersDEWService,
+                 auth_service: AuthService):
+        self.member_dew_service = member_dew_service
+        self.auth_service = auth_service
+
+        self.router = APIRouter(prefix="/members/{member_id}/dew", tags=["member-dew"])
+        self._setup_routes()
+
+    def get_router(self):
+        return self.router
+
+    def _setup_routes(self):
+
+        @self.router.get(
+            "/",
+            response_model=Optional[MembersDEWResponse],
+            # dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
+        )
+        def find_dew_by_id(member_id : int, db: Session = Depends(get_db)):
+            member_dew = self.member_dew_service.find_by_id(member_id, db)
+            if not member_dew:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+            return member_dew

--- a/app/routers/member_family_data.py
+++ b/app/routers/member_family_data.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    status,
+)
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import (
+    MemberFamilyDataResponse,
+)
+from app.services import (
+    AuthService,
+    MembersFamilyDataService,
+)
+
+
+class MemberFamilyDataRouter:
+    def __init__(self,
+                 member_family_data_service: MembersFamilyDataService,
+                 auth_service: AuthService):
+        self.member_family_data_service = member_family_data_service
+        self.auth_service = auth_service
+
+        self.router = APIRouter(prefix="/members/{member_id}/family-data", tags=["member-family-data"])
+        self._setup_routes()
+
+    def get_router(self):
+        return self.router
+
+    def _setup_routes(self):
+
+        @self.router.get(
+            "/",
+            response_model=Optional[MemberFamilyDataResponse],
+            # dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
+        )
+        def find_family_data_by_id(member_id : int, db: Session = Depends(get_db)):
+            member_family_data = self.member_family_data_service.find_by_member_id(member_id, db)
+            if not member_family_data:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+            return member_family_data

--- a/app/routers/member_general_data.py
+++ b/app/routers/member_general_data.py
@@ -1,0 +1,52 @@
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    status,
+)
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import (
+    MemberGeneralDataResponse, CreateMemberGeneralDataRequest,
+)
+from app.services import (
+    AuthService,
+    MembersGeneralDataService,
+)
+
+
+class MemberGeneralDataRouter:
+    def __init__(self,
+                 member_general_data_service: MembersGeneralDataService,
+                 auth_service: AuthService,
+                 ):
+        self.member_general_data_service = member_general_data_service
+        self.auth_service = auth_service
+        self.router = APIRouter(prefix="/members/{member_id}/general-data", tags=["member-general-data"])
+        self._setup_routes()
+
+    def get_router(self):
+        return self.router
+
+    def _setup_routes(self):
+        @self.router.get(
+            "/",
+            description="Get 'Member General Data' given the member ID",
+            response_model=MemberGeneralDataResponse,
+            # dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
+        )
+        def find_general_data_by_member_id(member_id : int, db: Session = Depends(get_db)):
+            member_general_data = self.member_general_data_service.find_by_id(member_id, db)
+            if not member_general_data:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+            return member_general_data
+
+        @self.router.post(
+            "/",
+            description="Save 'Member General Data' given the member ID",
+            response_model=MemberGeneralDataResponse,
+            dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
+        )
+        def find_general_data_by_member_id(new_member_data : CreateMemberGeneralDataRequest, db: Session = Depends(get_db)):
+            return self.member_general_data_service.create_member_general_data(new_member_data, db)

--- a/app/routers/member_reference.py
+++ b/app/routers/member_reference.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    status,
+)
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import (
+    MemberReferenceResponse,
+)
+from app.services import (
+    AuthService,
+    MembersReferenceService,
+)
+
+
+class MemberReferenceRouter:
+    def __init__(self,
+                 member_reference_service: MembersReferenceService,
+                 auth_service: AuthService
+                 ):
+        self.member_reference_service = member_reference_service
+        self.auth_service = auth_service
+
+        self.router = APIRouter(prefix="/members/{member_id}/references", tags=["member-reference"])
+        self._setup_routes()
+
+    def get_router(self):
+        return self.router
+
+    def _setup_routes(self):
+
+        @self.router.get(
+            "/",
+            response_model=Optional[MemberReferenceResponse],
+            # dependencies=[Depends(self.auth_service.require_role(["admin", "pastor"]))]
+        )
+        def find_references_by_member_id(member_id : int, db: Session = Depends(get_db)):
+            member_references = self.member_reference_service.find_by_id(member_id, db)
+            if not member_references:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+            return member_references

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,5 +1,5 @@
 from app.services.auth import AuthService
-from app.services.exception import LogicConstraintViolationException
+from app.services.exception import LogicConstraintViolationException, NotFoundException, ConflictException
 from app.services.health import HealthService
 from app.services.member import MemberService
 from app.services.member_dew import MembersDEWService

--- a/app/services/exception.py
+++ b/app/services/exception.py
@@ -8,3 +8,8 @@ class NotFoundException(Exception):
     def __init__(self, msg):
         super().__init__(self, msg)
         self.message = msg
+
+class ConflictException(Exception):
+    def __init__(self, msg):
+        super().__init__(self, msg)
+        self.message = msg

--- a/app/services/member_general_data.py
+++ b/app/services/member_general_data.py
@@ -1,15 +1,38 @@
 from sqlalchemy.orm import Session
 
-from app.database import MembersGeneralData
-from app.models import MemberGeneralDataResponse
+from app.database import MembersGeneralData, Member
+from app.middlewares import current_user_ctx
+from app.models import MemberGeneralDataResponse, CreateMemberGeneralDataRequest
+from app.services import NotFoundException, ConflictException
 
 
 class MembersGeneralDataService:
     def __init__(self):
         pass
 
-    def find_by_id(self, id, db: Session) -> MemberGeneralDataResponse | None:
-        member = db.query(MembersGeneralData).filter(MembersGeneralData.member_id == id).first()
+    def find_by_id(self, member_id : int, db: Session) -> MemberGeneralDataResponse | None:
+        member = db.query(MembersGeneralData).filter(MembersGeneralData.member_id == member_id).first()
         if not member:
             return None
         return MemberGeneralDataResponse.from_orm(member)
+
+    def create_member_general_data(self, new_member_general_data: CreateMemberGeneralDataRequest, db: Session) -> MemberGeneralDataResponse:
+        member = db.query(Member).filter(Member.id == new_member_general_data.member_id).first()
+        if not member:
+            raise NotFoundException(f'El miembro con id {member.id} no existe.')
+
+        self.validate_member_general_data(new_member_general_data.member_id, db)
+
+        db_member_general_data = MembersGeneralData(**new_member_general_data.model_dump(exclude_unset=True))
+        db.add(db_member_general_data)
+
+        member.updated_by = current_user_ctx.get().username
+        db.commit()
+        db.refresh(db_member_general_data)
+        db.refresh(member)
+        return MemberGeneralDataResponse.model_validate(db_member_general_data)
+
+    def validate_member_general_data(self, member_id: int, db: Session):
+        member_general_data = self.find_by_id(member_id , db)
+        if member_general_data:
+            raise ConflictException(f'El miembro con id {member_id} ya tiene datos generales')


### PR DESCRIPTION
- Se reorganiza el router de miembros, dividiendo en distintos routers cada parte de los datos del miembro, pero bajo la misma ruta `/members`
- Se crea servicio POST de general data

![image](https://github.com/user-attachments/assets/0521cbaf-47f3-4345-9e17-efb9756e0505)
